### PR TITLE
Add key bindings for individual alloy files

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
 	"args": ["run", "compile", "--loglevel", "silent"],
 
 	// The tsc compiler is started in watching mode
-	"isWatching": true,
+	"isBackground": true,
 
 	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
 	"problemMatcher": "$tsc-watch"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,18 @@
         "title": "Alloy: Open Relative Files"
       },
       {
+        "command": "extension.openAlloyController",
+        "title": "Alloy: Open Relative Controller"
+      },
+      {
+        "command": "extension.openAlloyView",
+        "title": "Alloy: Open Relative View"
+      },
+      {
+        "command": "extension.openAlloyStyle",
+        "title": "Alloy: Open Relative Style"
+      },
+      {
         "command": "extension.tiBuild",
         "title": "Titanium: build"
       },
@@ -40,11 +52,23 @@
     "keybindings": [
       {
         "command": "extension.openAlloyFiles",
-        "key": "ctrl+l"
+        "key": "ctrl+l",
+        "mac": "cmd+l"
       },
       {
-        "command": "extension.openAlloyFiles",
-        "key": "cmd+l"
+        "command": "extension.openAlloyController",
+        "key": "ctrl+shift+c",
+        "mac": "cmd+shift+c"
+      },
+      {
+        "command": "extension.openAlloyView",
+        "key": "ctrl+shift+v",
+        "mac": "cmd+shift+v"
+      },
+      {
+        "command": "extension.openAlloyStyle",
+        "key": "ctrl+shift+s",
+        "mac": "cmd+shift+s"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import {BuildOption, TiBuild} from './lib/TiBuild'
-
+import * as alloy from './lib/alloy'
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -30,6 +30,15 @@ export function activate(context: vscode.ExtensionContext) {
     .then(() => console.log("done"), (e) => console.error(e));
 	}));
 
+  context.subscriptions.push(vscode.commands.registerCommand('extension.openAlloyView', () => {
+    return alloy.openComponent('view');
+  }));
+  context.subscriptions.push(vscode.commands.registerCommand('extension.openAlloyController', () => {
+    return alloy.openComponent('controller');
+  }));
+  context.subscriptions.push(vscode.commands.registerCommand('extension.openAlloyStyle', () => {
+    return alloy.openComponent('style');
+  }));
   context.subscriptions.push(vscode.commands.registerCommand('extension.tiBuild', () => {
     return new TiBuild(BuildOption.Normal).launch();
 	}));

--- a/src/lib/alloy.ts
+++ b/src/lib/alloy.ts
@@ -1,0 +1,88 @@
+import * as vscode from 'vscode';
+
+//workaround for string enum 
+//https://stackoverflow.com/questions/15490560/create-an-enum-with-string-values-in-typescript
+export type Component = "controller" | "view" | "style";
+
+
+ /**
+ * Open the controller, view or style file relative to the currently opened file
+ * @param type {Component} what component to be opened - view, controller or style
+ * @returns {TextDocument} Thenable that resolves TextDocument
+ */
+export function openComponent(type: Component): Thenable<vscode.TextDocument>{
+
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) { return; }
+    const document = editor.document;
+
+    const file_name = document.fileName;
+
+    let config = vscode.workspace.getConfiguration("alloy");
+
+    //the current file extension
+    const currentFileExt = file_name.substring(file_name.lastIndexOf('.'), file_name.length) || file_name;
+
+    //skip if we are trying to change to same file type
+    if (currentFileExt === config[type]) { return; }
+
+    //get the current file 'type' based on the extension
+    const currentFileType = Object.keys(config).find(key => config[key] === currentFileExt);
+
+    //map our folder names to the file 'type'
+    let paths = {
+        'view': 'views',
+        'controller': 'controllers',
+        'style': 'styles'
+    };
+
+    const regexExt = new RegExp(currentFileExt + "$");
+
+    //set the new directory and create the new file path
+    const regexDir = new RegExp(paths[currentFileType]);
+    const newFile = file_name.replace(regexDir, paths[type]).replace(regexExt, config[type]);
+
+    //If the new file is already opened, we will just focus on it, otherwise, open the new file
+    let promise;
+    const currentlyOpenedDoc = vscode.workspace.textDocuments.find(obj => obj.fileName === newFile);
+
+    /**
+     * If the document is already open in another editor, focus on that editor instead of opening a new doc.
+     * However, the API doesn't currently track the viewColumn of all open docs, just the 'visible' editor/doc
+     * (the active tab) in each column.  So we may be opening a new doc even though the same doc is 
+     * in a hidden tab.
+     * https://github.com/Microsoft/vscode/issues/15178
+     */
+
+    //default to current column
+    var activeColumn = vscode.window.activeTextEditor.viewColumn;
+    var allDocs = vscode.workspace.textDocuments.map((doc) => ({ fileName: doc.fileName, viewColumn: activeColumn }));
+
+    //take the array of visible editors and map the visible doc in each to a column
+    var editors = vscode.window.visibleTextEditors
+        .map(editor => ({ fileName: editor.document.fileName, viewColumn: editor.viewColumn }))
+        .sort((a, b) => a.viewColumn - b.viewColumn);
+
+    //
+    allDocs.forEach(function (mp, idx) {
+        var c = editors.findIndex(e => e.fileName === mp.fileName)
+
+        if (c > -1) {
+            mp.viewColumn = c + 1;
+        }
+
+    });
+
+    if (currentlyOpenedDoc) {
+        //grab the column number for the currently opened doc
+        var column = allDocs.find(col => col.fileName === currentlyOpenedDoc.fileName).viewColumn;
+        promise = vscode.window.showTextDocument(currentlyOpenedDoc, column);
+
+    } else {
+        promise = vscode.workspace.openTextDocument(newFile)
+            .then((doc: vscode.TextDocument) => vscode.window.showTextDocument(doc, activeColumn));
+    }
+
+    return promise
+        .then(() => console.log("done"), (e) => console.error(e));
+}


### PR DESCRIPTION
Hi David, this PR adds keybindings for opening individual alloy component files, similar to the bindings in Appc Studio.  

As with ctrl+l, when focused on an alloy component file, doing one of the following will open the respective view, controller or style file:

ctrl[cmdl]+v — open view
ctrl[cmdl]+c — open controller
ctrl[cmdl]+s — open style

If the file in question is already open, it will attempt to focus on it.  This won’t always work due to: https://github.com/Microsoft/vscode/issues/15178